### PR TITLE
Index reference before samtools and ivar access the reference in callVariants step

### DIFF
--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -44,6 +44,7 @@ process indexReference {
         """
         ln -s ${ref} ref.fa
         bwa index ref.fa
+        samtools faidx ref.fa
         """
 }
 


### PR DESCRIPTION
Jared and Larry found this error occurs sometimes during the callVariants step:
```
[E::faidx_adjust_position] The sequence "MN908947.3" not found
```

Force the reference index to be created before this step.

See GC-7834.